### PR TITLE
Fix missing function

### DIFF
--- a/lib/html-injector.js
+++ b/lib/html-injector.js
@@ -86,7 +86,7 @@ exports.inject = function(html, lassoPageResult, options) {
     var keepMarkers = options.keepMarkers !== false;
     var injector = new HtmlInjector(html, keepMarkers);
 
-    var slots = lassoPageResult.getHtmlBySlot();
+    var slots = lassoPageResult.htmlBySlot;
     for (var slotName in slots) {
         if (slots.hasOwnProperty(slotName)) {
             injector.inject(slotName, slots[slotName]);


### PR DESCRIPTION
Because of update there is no getHtmlBySlot function in lasso. It is refactored to a getter called htmlBySlot. This is a fix that is working for me.