### PR TITLE
Remove name config parameter, because it is invalid lasso parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = function (options) {
     delete config.dependencies;
     delete config.mode;
     delete config.configFile;
+    delete config.name;
 
     if (configFile) {
         try {


### PR DESCRIPTION
It causes me a problem, because the lasso says "Invalid option of "name". Allowed: require, ...."
But the name parameter is useful and I would like to use it, so I removed it from config and not pass to lasso.
